### PR TITLE
fixed no args error

### DIFF
--- a/v_JSON.vbs
+++ b/v_JSON.vbs
@@ -40,7 +40,6 @@ Class v_JSON
 
 	' Properties
 
-
 	Public Default Property Get Item(strKey)
 		If pScript.Run("getItemType", Array(strKey)) = "object" Then
 			Set Item = Deserialize(pScript.Run("getItemValue", Array(strKey)))


### PR DESCRIPTION
File v_Script.vbs, function Run. When a function with no args is passed, line: 

`strArgs = strArgs & "arrArgs(" & i & "), "` 

never gets executed, leaving strArgs with the value "(", then it is passed to 

`strArgs = Left(strArgs, Len(strArgs) - 2) & ")"`

where `Len(strArgs) -2 = -1`, causing `Left(strArgs, -1)` to crash the execution flow.

